### PR TITLE
ops-npm-install uses npm 2

### DIFF
--- a/ops-npm-install.sh
+++ b/ops-npm-install.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -ex
 
+npm install -g npm@2.x
+
 # environment info
 node -v
 npm -v


### PR DESCRIPTION
All ops apps' `.travis.yml`s have been [pointed at this `npm2` branch](https://github.com/goodeggs/ops-inventory-ui/blob/06d77871a588362abd9b15e269aa4cd57f3cd819/.travis.yml#L31) for seven months now.  And I've just tried using this in a `.ecru` file to run NPM 2 on Ecru without a hitch [here](https://github.com/goodeggs/ops-inventory-ui/blob/949eec76a9debb52965c1efad7d134a2033f4d90/.ecru#L10).  Might as well just merge?