### PR TITLE
Start xvfb from chrome script, not chromedriver script.

### DIFF
--- a/chrome.sh
+++ b/chrome.sh
@@ -30,3 +30,5 @@ fi
 curl -Lo chrome-sandbox https://github.com/goodeggs/travis-utils/raw/master/vendor/chrome-sandbox
 sudo install -m 4755 chrome-sandbox $CHROME_SANDBOX
 
+export DISPLAY=:99.0
+sh -e /etc/init.d/xvfb start

--- a/chromedriver.sh
+++ b/chromedriver.sh
@@ -5,6 +5,4 @@ CHROMEDRIVER=chromedriver_linux64.zip
 curl -Lo $CHROMEDRIVER http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION:-2.21}/$CHROMEDRIVER
 unzip $CHROMEDRIVER
 
-export DISPLAY=:99.0
-sh -e /etc/init.d/xvfb start
 ./chromedriver "$@" &


### PR DESCRIPTION
Karma tests don't use chromedriver but they need xvfb.

Cool to merge, @bobzoller?