### PR TITLE
shared ops-ui-deploy script

### DIFF
--- a/ops-ui-deploy.sh
+++ b/ops-ui-deploy.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -ex
+
+: "${ECRU_COMMIT:?must be set}"
+: "${S3_STAGING_BUCKET:?must be set}"
+: "${S3_PRODUCTION_BUCKET:?must be set}"
+: "${AWS_ACCESS_KEY_ID:?must be set}"
+: "${AWS_SECRET_ACCESS_KEY:?must be set}"
+
+deploy_to_s3 () {
+  bucket=$1
+  aws s3 cp build s3://${bucket}/ --recursive --exclude "index.html"
+  aws s3 cp build/index.html s3://${bucket}/
+}
+
+# Write version.js
+commit=$ECRU_COMMIT
+echo "module.exports = '$commit';" > ./version.js
+
+# Deploy to staging
+SHA=$commit NODE_ENV=production BUILD_ENV=production APP_INSTANCE=staging npm run predeploy
+deploy_to_s3 $S3_STAGING_BUCKET
+npm run postdeploy
+
+# Smoke tests
+retry () { for i in 1 2 3; do "$@" && return || sleep 10; done; exit 1; }
+smoke_test () { SMOKE_TEST_ENV=staging npm run test:smoke; }
+retry smoke_test
+
+# Deploy to production
+SHA=$commit NODE_ENV=production BUILD_ENV=production APP_INSTANCE=production npm run predeploy
+deploy_to_s3 $S3_PRODUCTION_BUCKET
+npm run postdeploy


### PR DESCRIPTION
@bobzoller @serhalp I haven't actually tried this yet but would love to get your feedback
on the structure / division of responsibility before going farther. It seems like we have 5 steps for a UI deploy:

1. build bundles
2. deploy to staging
3. smoke tests
4. deploy to production
5. purge fastly

With the non UI deploys via `ops-deploy.sh` we do the following:

1. expect the app to define `npm run predeploy` that builds the app
2. shell script takes care of deploying to staging
3. expect the app to define `npm run test:smoke`
4. shell script takes care of deploying to production
5. expect the app to define `npm run postdeploy` to, for example, purge fastly

I think the same pattern makes sense except for maybe purging fastly. That seems
like the business of the deploy job, so maybe it should be in the script itself
and it can still callout to `npm run postdeploy` in case an app wants to do any
final steps.

Thoughts?