### PR TITLE
Fix Chrome version substitution

### DIFF
--- a/chrome.sh
+++ b/chrome.sh
@@ -12,10 +12,10 @@ sudo apt-get update --fix-missing || true
 
 sudo ln -sf $(which true) $(which xdg-desktop-menu)
 
-CHROME=google-chrome-${CHROME_VERSION:-stable}_current_amd64.deb
-#curl -Lo $CHROME https://dl.google.com/linux/direct/$CHROME
-curl -Lo $CHROME https://s3.amazonaws.com/travis-utils/google-chrome-stable_54.0.2840_amd64.deb
-if ! sudo dpkg --install $CHROME; then
+CHROME_VERSION="${CHROME_VERSION:-stable}"
+CHROME="google-chrome-stable_${CHROME_VERSION}_amd64.deb"
+curl -Lo "${CHROME}" "https://dl.google.com/linux/direct/${CHROME}"
+if ! sudo dpkg --install "${CHROME}"; then
   sudo apt-get -y --fix-broken install
 fi
 
@@ -28,7 +28,7 @@ fi
 
 # Download a custom chrome-sandbox which works inside OpenVC containers (used on travis).
 curl -Lo chrome-sandbox https://github.com/goodeggs/travis-utils/raw/master/vendor/chrome-sandbox
-sudo install -m 4755 chrome-sandbox $CHROME_SANDBOX
+sudo install -m 4755 chrome-sandbox "${CHROME_SANDBOX}"
 
 export DISPLAY=:99
 sh /etc/init.d/xvfb start || true # might already be started

--- a/chromedriver.sh
+++ b/chromedriver.sh
@@ -2,7 +2,7 @@
 set -ex
 
 CHROMEDRIVER=chromedriver_linux64.zip
-curl -Lo $CHROMEDRIVER http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION:-2.24}/$CHROMEDRIVER
+curl -Lo $CHROMEDRIVER http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION:-2.43}/$CHROMEDRIVER
 unzip $CHROMEDRIVER
 
 export DISPLAY=:99.0

--- a/install-ci-tools.sh
+++ b/install-ci-tools.sh
@@ -26,7 +26,7 @@ blessed_version () {
     docker-compose)
       echo 1.19.0 ;;
     chromedriver)
-      echo 2.27 ;;
+      echo 2.43 ;;
     yarn)
       echo 0.19.0 ;;
     node)
@@ -253,4 +253,3 @@ EOF
   esac
   echo "✔"
 done
-


### PR DESCRIPTION
This may not be a _bug_, but looks like we're not subbing CHROME_VERSION
into our curl in the install-Chrome script. This fixes that, and also
retrieves it from the official Chrome mirror--not sure why we were
retrieving it from our own S3 bucket.

Also changed some quotes so we never run into word splitting issues,
blablabla probably never gonna happen but it makes shellcheck happy.

Pivotal Story: [#157209965](https://www.pivotaltracker.com/story/show/157209965)