### PR TITLE
UI deploy script allows not having a staging env.

### DIFF
--- a/ops-ui-deploy.sh
+++ b/ops-ui-deploy.sh
@@ -3,7 +3,6 @@ set -ex
 
 # Assert required env variables are defined
 : "${ECRU_COMMIT:?must be set}"
-: "${S3_STAGING_BUCKET:?must be set}"
 : "${S3_PRODUCTION_BUCKET:?must be set}"
 : "${AWS_DEFAULT_REGION:?must be set}"
 : "${AWS_ACCESS_KEY_ID:?must be set}"
@@ -19,10 +18,21 @@ deploy_to_s3 () {
 commit=$ECRU_COMMIT
 echo "module.exports = '$commit';" > ./version.js
 
-# Deploy to staging
-SHA=$commit NODE_ENV=production BUILD_ENV=production APP_INSTANCE=staging npm run predeploy
-deploy_to_s3 $S3_STAGING_BUCKET
-FASTLY_SERVICE=$STAGING_FASTLY_SERVICE npm run postdeploy
+# Deploy to staging, if necessary. Set `NO_STAGING` to `1` if no staging environment.
+if [ "$NO_STAGING" == 1 ]
+then
+  echo 'No staging environment. Skipping deploy to staging and smoke test.'
+else
+  : "${S3_STAGING_BUCKET:?must be set}"
+  SHA=$commit NODE_ENV=production BUILD_ENV=production APP_INSTANCE=staging npm run predeploy
+  deploy_to_s3 $S3_STAGING_BUCKET
+  FASTLY_SERVICE=$STAGING_FASTLY_SERVICE npm run postdeploy
+
+  # Smoke tests
+  retry () { for i in 1 2 3; do "$@" && return || sleep 10; done; exit 1; }
+  smoke_test () { SMOKE_TEST_ENV=staging npm run test:smoke; }
+  retry smoke_test
+fi
 
 # Abort if not deploying to production
 if [ "$DEPLOY_PRODUCTION" != 1 ]
@@ -30,11 +40,6 @@ then
   echo 'STOPPING AT STAGING. Toggle `env.DEPLOY_PRODUCTION` to go all the way.'
   exit 0
 fi
-
-# Smoke tests
-retry () { for i in 1 2 3; do "$@" && return || sleep 10; done; exit 1; }
-smoke_test () { SMOKE_TEST_ENV=staging npm run test:smoke; }
-retry smoke_test
 
 # Deploy to production
 SHA=$commit NODE_ENV=production BUILD_ENV=production APP_INSTANCE=production npm run predeploy


### PR DESCRIPTION
Set `NO_STAGING` to `1` if no staging environment. It seemed better to opt out because nearly every app does have a staging env.

Necessary for https://github.com/goodeggs/it-accounts-ui/pull/17 to start using this script.