### PR TITLE
goodeggs-deploy supports custom goodeggs-stats args.

### DIFF
--- a/goodeggs-deploy.sh
+++ b/goodeggs-deploy.sh
@@ -27,18 +27,16 @@ else
 fi
 
 # Apply changes to Statsfile, if any.
-if [ -f ./Statsfile.coffee ]; then
-  is_babel=
-  statsfile_hash=$(coffee -e 'console.log(JSON.stringify(require("./Statsfile.coffee")))' | tail -1 | md5sum | cut -d ' ' -f 1)
-elif [ -f ./Statsfile.js ]; then
-  is_babel=1
+if [ -f ./Statsfile.js ]; then
   # NOTE: importing Statsfile may import some app modules and log things, so we hash only on the last logged line
   # For example, apps are known to log "STATUS_API_TOKEN required, but not set. Configuring goodeggs-status in simulate mode"
   # within a full JSON log line with a timestamp - which makes this hashing nondeterministic. :(
   statsfile_hash=$(babel-node -e 'console.log(JSON.stringify(require("./Statsfile.js")))' | tail -1 | md5sum | cut -d ' ' -f 1)
 fi
 apply_statsfile() {
-  if [ ! -z $is_babel ]; then args='--require=babel-register'; fi
+  # Assume babel 6 if not overriden. Someday we should remove this.
+  DEFAULT_GOODEGGS_STATS_ARGS='--require=babel-register'
+  args=${GOODEGGS_STATS_ARGS-$DEFAULT_GOODEGGS_STATS_ARGS}
   goodeggs-stats $args
   if [ ! -d ./.goodeggs-stats-state ]; then mkdir ./.goodeggs-stats-state; fi
   echo $statsfile_hash > ./.goodeggs-stats-state/md5_hash


### PR DESCRIPTION
This allows apps to support babel 7 by running this script in `.ecru` with `GOODEGGS_STATS_ARGS='--require=@babel/register'`.

This maintains backwards compatibility by using `--require=babel-register` as a default.

This also removes support for CoffeeScript, as we longer have any CoffeeScript apps that use this deploy script.