### PR TITLE
Automatically determine version of Chromedriver to install, from Chrome version.

### DIFF
--- a/chromedriver.sh
+++ b/chromedriver.sh
@@ -2,7 +2,16 @@
 set -ex
 
 CHROMEDRIVER=chromedriver_linux64.zip
-curl -Lo $CHROMEDRIVER http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION:-2.43}/$CHROMEDRIVER
+
+# See http://chromedriver.chromium.org/downloads/version-selection.
+if ! which google-chrome; then
+  echo "Must have google-chrome installed to determine default version of chromedriver to install."
+  exit 1
+fi
+CHROME_VERSION=$(google-chrome --version | grep -oE "[0-9]+.[0-9]+.[0-9]+")
+DEFAULT_CHROMEDRIVER_VERSION=$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION)
+
+curl -Lo $CHROMEDRIVER http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION:-$DEFAULT_CHROMEDRIVER_VERSION}/$CHROMEDRIVER
 unzip $CHROMEDRIVER
 
 export DISPLAY=:99.0


### PR DESCRIPTION
See http://chromedriver.chromium.org/downloads/version-selection.

Otherwise every few months the latest Chrome stable version is no longer supported by the hardcoded Chromedriver version and we have to do some manual bumping in a number of places.

Continue to allow overriding with an env var, just in case.