### PR TITLE
rollback ranch proxy

### DIFF
--- a/install-ci-tools.sh
+++ b/install-ci-tools.sh
@@ -205,17 +205,13 @@ EOF
 #!/bin/bash
 
 set -euo pipefail
-export ssh_pid=''
-
-function cleanup {
-  [[ "$ssh_pid" != '' ]] && kill $ssh_pid; exit 0
-}
 
 # Make sure and clean up
 trap "exit" INT TERM ERR
-trap "cleanup" EXIT
+trap "kill 0" EXIT
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+exec "$script_dir/ranch_real" "$@"
 
 if [ -z "${RANCH_PROXY_SSH_KEY:-}" ]
 then
@@ -234,12 +230,10 @@ case "${RANCH_ENDPOINT:-}" in
   *huevosbuenos.com*)
     export RANCH_ENDPOINT="https://ranch-api-staging.internal.huevosbuenos.com"
     $sshcmd -D 8005 jump.us-east-1.dev-aws.goodeggs.com "sleep 3600" &
-    ssh_pid=$!
     ;;
   *)
     export RANCH_ENDPOINT="https://ranch-api.internal.goodeggs.com"
     $sshcmd -D 8005 jump.us-east-1.prod-aws.goodeggs.com "sleep 3600" &
-    ssh_pid=$!
     ;;
   esac
 sleep 1


### PR DESCRIPTION
garbanzo's failing to pull a docker image and I'm clutching at straws trying to explain the change in behavior.
- ecru didn't change (or restart)
- the permissions on the docker image didn't change
- we've tried yesterday's docker image version (1.8.1) and today's new one (1.9.1)
- no material changes within garbanzo itself

https://ecru.goodeggs.com/projects/5453ff6b449dab02004b3b8f/builds/5efbc1b425d068000eb70626