### PR TITLE
fix: fix install-ci-tools syntax

### DIFF
--- a/install-ci-tools.sh
+++ b/install-ci-tools.sh
@@ -205,12 +205,6 @@ EOF
         chmod +x ranch
       fi
       ;;
-#!/bin/sh
-set -e
-git log --format=full "\$ECRU_LIVE_COMMIT..\$ECRU_COMMIT" | pivotal-deliver
-EOF
-      chmod +x deliver-pivotal-stories
-      ;;
     packer)
       if [ ! -x packer ] || ./packer -v | egrep -qv "\\b${version}\\b"; then
         curl -sSLo tmp.zip "https://releases.hashicorp.com/packer/${version}/packer_${version}_linux_amd64.zip"


### PR DESCRIPTION
My bad. I removed half this block in https://github.com/goodeggs/travis-utils/commit/0290ef1d4c94e58485ca69be7932161be91fdae1.