### PR TITLE
chore: use systemctl to start xvfb with fallback for trusty

### DIFF
--- a/chrome.sh
+++ b/chrome.sh
@@ -33,4 +33,8 @@ curl -Lo chrome-sandbox https://github.com/goodeggs/travis-utils/raw/master/vend
 sudo install -m 4755 chrome-sandbox "${CHROME_SANDBOX}"
 
 export DISPLAY=:99
-sh /etc/init.d/xvfb start || true # might already be started
+if lsb_release -a | grep -q trusty; then
+  sh /etc/init.d/xvfb start || true # might already be started
+else
+  sudo systemctl start xvfb # systemctl will not error if already started
+fi


### PR DESCRIPTION
In order to upgrade Ubuntu to resolve a cert issue, we need to change how xvfb is started.

This includes a fallback for `trusty` - there shouldn't be too many repos running on this version, but backwards compatibility will be preserved for now.