### PR TITLE
fix(goodeggs-deploy): add missing support for other Statsfile extensions

### DIFF
--- a/goodeggs-deploy.sh
+++ b/goodeggs-deploy.sh
@@ -33,12 +33,13 @@ else
   echo "DEPLOY_PRODUCTION env var is not set to 1. Not deploying to production."
 fi
 
-# Apply changes to Statsfile, if any.
-if [ -f ./Statsfile.js ]; then
+# Apply changes to Statsfile (.js, .babel.ts, .coffee, etc.), if any.
+statsfile=$(ls Statsfile.*)
+if [ -f "$statsfile" ]; then
   # NOTE: importing Statsfile may import some app modules and log things, so we hash only on the last logged line
   # For example, apps are known to log "STATUS_API_TOKEN required, but not set. Configuring goodeggs-status in simulate mode"
   # within a full JSON log line with a timestamp - which makes this hashing nondeterministic. :(
-  statsfile_hash=$(babel-node -e 'console.log(JSON.stringify(require("./Statsfile.js")))' | tail -1 | md5sum | cut -d ' ' -f 1)
+  statsfile_hash=$(babel-node -e "console.log(JSON.stringify(require('./$statsfile')))" | tail -1 | md5sum | cut -d ' ' -f 1)
 fi
 apply_statsfile() {
   # Assume babel 6 if not overriden. Someday we should remove this.


### PR DESCRIPTION
Oops. This means there's been no "caching" (skipping of the goodeggs-stats apply if nothing has changed) in our apps that use a TypeScript file, etc.