### PR TITLE
Replace use of lsb_release

### DIFF
--- a/chrome.sh
+++ b/chrome.sh
@@ -33,7 +33,7 @@ curl -Lo chrome-sandbox https://github.com/goodeggs/travis-utils/raw/master/vend
 sudo install -m 4755 chrome-sandbox "${CHROME_SANDBOX}"
 
 export DISPLAY=:99
-if lsb_release -a | grep -q trusty; then
+if ! [ -x "$(command -v systemctl)" ]; then
   sh /etc/init.d/xvfb start || true # might already be started
 else
   sudo systemctl start xvfb # systemctl will not error if already started


### PR DESCRIPTION
Previously, we were using `lsb_release` to check the version of Linux to determine if we should use systemd's `systemctl` to start `xvfb` or not. 

It appears that at least one of the images running this does not have `lsb_release` installed. We can use `command` to check for the same thing - if `systemctl` is not present, start `xvfb` using init.d, but if it is, use `systemctl`.