### PR TITLE
Use a different method of checking for systemd

### DIFF
--- a/chrome.sh
+++ b/chrome.sh
@@ -33,7 +33,7 @@ curl -Lo chrome-sandbox https://github.com/goodeggs/travis-utils/raw/master/vend
 sudo install -m 4755 chrome-sandbox "${CHROME_SANDBOX}"
 
 export DISPLAY=:99
-if ! [ -x "$(command -v systemctl)" ]; then
+if ! [ -x /run/systemd/system ] then
   sh /etc/init.d/xvfb start || true # might already be started
 else
   sudo systemctl start xvfb # systemctl will not error if already started


### PR DESCRIPTION
This is based on https://superuser.com/a/1631444 - checking `/run/systemd/system` is apparently how functions internal to systemd check for its operation.