### PR TITLE
chore: replace all uses of "npm run" with "yarn run"

### DIFF
--- a/goodeggs-deploy.sh
+++ b/goodeggs-deploy.sh
@@ -9,7 +9,7 @@ commit=$BUILDKITE_COMMIT
 [ -n "$commit" ] || commit=$ECRU_COMMIT
 [ -n "$commit" ] || commit=$(git rev-parse HEAD)
 
-SHA=$commit npm run predeploy
+SHA=$commit yarn run predeploy
 echo "module.exports = '$commit';" > ./version.js
 
 STAGING_RANCH_FILE='.ranch.staging.yaml'
@@ -18,8 +18,8 @@ PRODUCTION_RANCH_FILE=$([ -f '.ranch.production.yaml' ] && echo '.ranch.producti
 # Deploy staging
 if [ -f "$STAGING_RANCH_FILE" ]; then
   ranch deploy -f "$STAGING_RANCH_FILE"
-  ranch run -f "$STAGING_RANCH_FILE" -- npm run postdeploy
-  smoke_test () { SMOKE_TEST_ENV=staging npm run test:smoke; }
+  ranch run -f "$STAGING_RANCH_FILE" -- yarn run postdeploy
+  smoke_test () { SMOKE_TEST_ENV=staging yarn run test:smoke; }
   retry smoke_test
 else
   echo "WARNING: $STAGING_RANCH_FILE not found, skipping staging deploy..."
@@ -28,7 +28,7 @@ fi
 if [ "$DEPLOY_PRODUCTION" = "1" ]; then
   # Deploy production
   ranch deploy -f "$PRODUCTION_RANCH_FILE"
-  ranch run -f "$PRODUCTION_RANCH_FILE" -- npm run postdeploy
+  ranch run -f "$PRODUCTION_RANCH_FILE" -- yarn run postdeploy
 else
   echo "DEPLOY_PRODUCTION env var is not set to 1. Not deploying to production."
 fi

--- a/ops-ui-deploy.sh
+++ b/ops-ui-deploy.sh
@@ -24,13 +24,13 @@ then
   echo 'No staging environment. Skipping deploy to staging and smoke test.'
 else
   : "${S3_STAGING_BUCKET:?must be set}"
-  SHA=$commit NODE_ENV=production BUILD_ENV=production APP_INSTANCE=staging npm run predeploy
+  SHA=$commit NODE_ENV=production BUILD_ENV=production APP_INSTANCE=staging yarn run predeploy
   deploy_to_s3 $S3_STAGING_BUCKET
-  FASTLY_SERVICE=$STAGING_FASTLY_SERVICE npm run postdeploy
+  FASTLY_SERVICE=$STAGING_FASTLY_SERVICE yarn run postdeploy
 
   # Smoke tests
   retry () { for i in 1 2 3; do "$@" && return || sleep 10; done; exit 1; }
-  smoke_test () { SMOKE_TEST_ENV=staging npm run test:smoke; }
+  smoke_test () { SMOKE_TEST_ENV=staging yarn run test:smoke; }
   retry smoke_test
 fi
 
@@ -42,6 +42,6 @@ then
 fi
 
 # Deploy to production
-SHA=$commit NODE_ENV=production BUILD_ENV=production APP_INSTANCE=production npm run predeploy
+SHA=$commit NODE_ENV=production BUILD_ENV=production APP_INSTANCE=production yarn run predeploy
 deploy_to_s3 $S3_PRODUCTION_BUCKET
-FASTLY_SERVICE=$PRODUCTION_FASTLY_SERVICE npm run postdeploy
+FASTLY_SERVICE=$PRODUCTION_FASTLY_SERVICE yarn run postdeploy


### PR DESCRIPTION
We should never, ever use the `npm` CLI, since we use `yarn`: https://goodeggs.atlassian.net/wiki/spaces/ENG/pages/459833453/Using+NPM+and+Yarn#Yarn.

Mixing them is a recipe for trouble. For example, right now, many of our apps are running into issues because of this when upgrading to Node 16.