### PR TITLE
fix(goodeggs-deploy): actually support all Statsfiles

### DIFF
--- a/goodeggs-deploy.sh
+++ b/goodeggs-deploy.sh
@@ -33,8 +33,17 @@ else
   echo "DEPLOY_PRODUCTION env var is not set to 1. Not deploying to production."
 fi
 
-# Apply changes to Statsfile (.js, .babel.ts, .coffee, etc.), if any.
-statsfile=$(ls Statsfile.*)
+# Apply changes to Statsfile, if any.
+# It's important to check not the _code contents_ of the file, but the final
+# exported result, since it may dynamically generate the final Statsfile config.
+# Unfortunately, the simplest way to be as broadly compatible as possible (w/
+# CoffeeScript, TypeScript, various versions of Babel, etc.) is to `require` the _built_
+# Statsfile - although note that below we don't end up actually exercising the built code.
+# I'm sorry this is confusing.
+# ASSUMPTIONS:
+# - code is built into `./build/`
+# - Statsfile is built (there's no other reason to do so)
+statsfile=$(ls build/Statsfile*.js)
 if [ -f "$statsfile" ]; then
   # NOTE: importing Statsfile may import some app modules and log things, so we hash only on the last logged line
   # For example, apps are known to log "STATUS_API_TOKEN required, but not set. Configuring goodeggs-status in simulate mode"


### PR DESCRIPTION
In https://github.com/goodeggs/travis-utils/pull/74, I tried to add missing support for `Statsfile`s not written as `.js` files.

Unfortunately, this doesn't really work. Since we `require` the Statsfile, we need to be configured with Babel, any hooks like `@babel/register`, and all that jazz, or it fails to parse. This would be a big pain, since apps have different setups.

See example error at the bottom of this build: https://ecru.goodeggs.com/projects/5a0e13c667ed811100ba2af3/builds/61b9db694e8c9600131ab858.

Instead, just `require` the _built_ Statsfile. That's mildly confusing, since we don't actually end up 'exercising' that file when we apply the Statsfile, but it seems OK.

I tried all this locally to verify.

Every app that uses this script except one builds its entire source to `build/`. This PR fixes the one exception: https://github.com/goodeggs/catalog-api/pull/4127.