### PR TITLE
fix: apply Statsfile on goodeggs-stats-cli version change

### DIFF
--- a/goodeggs-deploy.sh
+++ b/goodeggs-deploy.sh
@@ -49,6 +49,12 @@ if [ -f "$statsfile" ]; then
   # For example, apps are known to log "STATUS_API_TOKEN required, but not set. Configuring goodeggs-status in simulate mode"
   # within a full JSON log line with a timestamp - which makes this hashing nondeterministic. :(
   statsfile_hash=$(babel-node -e "console.log(JSON.stringify(require('./$statsfile')))" | tail -1 | md5sum | cut -d ' ' -f 1)
+  goodeggs_stats_cli_version=$(node -e 'console.log(require("./package.json").devDependencies["goodeggs-stats-cli"])')
+  if ["$goodeggs_stats_cli_version" = "null"]; then
+    echo "WARNING: Statsfile found but no dev dependency on goodeggs-stats-cli."
+    echo "Unable to reapply Statsfile when version changes."
+  fi
+  goodeggs_stats_state_hash="$statsfile_hash":"$goodeggs_stats_cli_version"
 fi
 apply_statsfile() {
   # Assume babel 6 if not overriden. Someday we should remove this.
@@ -57,14 +63,14 @@ apply_statsfile() {
   # shellcheck disable=SC2086
   goodeggs-stats $args
   if [ ! -d ./.goodeggs-stats-state ]; then mkdir ./.goodeggs-stats-state; fi
-  echo "$statsfile_hash" > ./.goodeggs-stats-state/md5_hash
+  echo "$goodeggs_stats_state_hash" > ./.goodeggs-stats-state/md5_hash
 }
 if [ ! -f ./.goodeggs-stats-state/md5_hash ]; then
   echo 'No cached Statsfile hash; applying it'
   apply_statsfile
 else
-  prev_statsfile_cache=$(cat ./.goodeggs-stats-state/md5_hash)
-  if [ "$statsfile_hash" != "$prev_statsfile_cache" ]; then
+  prev_goodeggs_stats_state_hash=$(cat ./.goodeggs-stats-state/md5_hash)
+  if [ "$goodeggs_stats_state_hash" != "$prev_goodeggs_stats_state_hash" ]; then
     echo 'Statsfile changed since last deploy; applying it'
     apply_statsfile
   else


### PR DESCRIPTION
I just made a change to goodeggs-stats-cli and got it bumped in like 15 apps, only to realize the Statsfile apply got skipped in all those apps. 😅

This is because we hash the export of the `Statsfile` and only apply it if has changed since the last apply, so when we upgrade goodeggs-stats-cli, this hasn't changed, so we skip the apply.

So, include the installed version in the hash.

 # To Do

- [x] @bobzoller I have no idea if `jq` is actually installed and available on ecru and in our Buildkite image. Is it?